### PR TITLE
Revert "Fixing the button IRQ state with the wifi sdk v3.4.1 (#253)"

### DIFF
--- a/board-support/si91x/support/hal/rsi_hal_mcu_m4.c
+++ b/board-support/si91x/support/hal/rsi_hal_mcu_m4.c
@@ -84,7 +84,7 @@ int soc_pll_config(void) {
 #ifdef SL_CATALOG_SIMPLE_BUTTON_PRESENT
 void sl_si91x_button_isr(uint8_t pin, int8_t state) {
   (pin == SL_BUTTON_BTN0_PIN)
-      ? sl_button_on_change(SL_BUTTON_BTN0_NUMBER, state)
-      : sl_button_on_change(SL_BUTTON_BTN1_NUMBER, state);
+      ? sl_button_on_change(SL_BUTTON_BTN0_NUMBER, !state)
+      : sl_button_on_change(SL_BUTTON_BTN1_NUMBER, !state);
 }
 #endif  //SL_CATALOG_SIMPLE_BUTTON_PRESENT


### PR DESCRIPTION
This reverts commit 203ae5b395f957c1c497e80f0066c5057db1130e.

This is a breaking change that cannot be used until we update the docker files to use wiseconnect 3.4.1. To unblock the restructuring of the repos, i'm reverting this so that the repo can be used on CSA.