### PR TITLE
Add initial workflow to process notification from the provisioning repository

### DIFF
--- a/.github/workflows/publish-provisoning.yaml
+++ b/.github/workflows/publish-provisoning.yaml
@@ -4,6 +4,7 @@ on:
     types: [trigger-workflow]
 jobs:
   run-tasks:
+    if: startsWith(github.event.client_payload.branch, 'release_') || github.event.client_payload.branch == 'main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/publish-provisoning.yaml
+++ b/.github/workflows/publish-provisoning.yaml
@@ -1,0 +1,13 @@
+name: Target Repository Workflow
+on:
+  repository_dispatch:
+    types: [trigger-workflow]
+jobs:
+  run-tasks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run tasks
+        run: echo "Running tasks on branch ${{ github.event.client_payload.branch }}..."


### PR DESCRIPTION
### Description
PR adds an initial PoC for a workflow that gets triggered from the provisioning repository when a push on main or release_* gets merged.

I can't test it without the workflow being on main first