### PR TITLE
Add gn files to be able to leverage provisioning files in matter_support

### DIFF
--- a/.github/workflows/prevent-provision-changes.yml
+++ b/.github/workflows/prevent-provision-changes.yml
@@ -28,7 +28,10 @@ jobs:
             const changedFiles = files.map(file => file.filename);
             console.log('Changed files:', changedFiles);
 
-            const unauthorizedChanges = changedFiles.some(file => file.startsWith('provision/'));
+            const unauthorizedChanges = changedFiles.some(file => 
+              file.startsWith('provision/libs/') || file.startsWith('provision/headers/')
+            );
+            
             if (unauthorizedChanges) {
-              core.setFailed(`Unauthorized changes detected in the provision/ directory by ${context.actor}`);
+              core.setFailed(`Unauthorized changes detected in the provision directory by ${context.actor}`);
             }

--- a/provision/BUILD.gn
+++ b/provision/BUILD.gn
@@ -1,0 +1,29 @@
+# Copyright (c) 2025 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+config("provision-config") {
+  include_dirs = [ "." ]
+}
+
+source_set("headers") {
+  sources = [
+    "headers/AttestationKey.h",
+    "headers/ProvisionChannel.h",
+    "headers/ProvisionEncoder.h",
+    "headers/ProvisionManager.h",
+    "headers/ProvisionProtocol.h",
+    "headers/ProvisionStorage.h",
+  ]
+  public_configs = [ ":provision-config" ]
+}

--- a/provision/BUILD.gn
+++ b/provision/BUILD.gn
@@ -12,8 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import("../../silabs_board.gni")
+
 config("provision-config") {
   include_dirs = [ "." ]
+
+  defines = [ "CHIP_DEVICE_CONFIG_ENABLE_EXAMPLE_CREDENTIALS=1" ]
+  if (use_provision_channel) {
+    defines += [ "SL_MATTER_PROVISION_CHANNEL_ENABLED=1" ]
+  }
 }
 
 source_set("headers") {

--- a/provision/args.gni
+++ b/provision/args.gni
@@ -1,0 +1,24 @@
+# Copyright (c) 2025 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("../../silabs_board.gni")
+if (wifi_soc) {
+  import("../../SiWx917_sdk.gni")
+} else {
+  import("../../efr32_sdk.gni")
+}
+
+declare_args() {
+  sl_provision_root = "${matter_support_root}/provision"
+}


### PR DESCRIPTION
#### Change overview
PR adds gn files to be able to build silabs examples while using the libs and the headers from matter_support.
These files are not generated for the moment and need to be manually maintained.

When the bot open a PR to update the libs or headers, a user can push additional commits to the same PR to update these files. We modify the verification workflow to allow changes to files in the root of provision/ but not in the subdirectories.

#### Testing
Built apps on CSA and commisionned them.