### PR TITLE
Remove dependency on silabs_board.gni

### DIFF
--- a/provision/BUILD.gn
+++ b/provision/BUILD.gn
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import("../../silabs_board.gni")
-
 config("provision-config") {
   include_dirs = [ "." ]
 

--- a/provision/args.gni
+++ b/provision/args.gni
@@ -12,13 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import("../../silabs_board.gni")
-if (wifi_soc) {
-  import("../../SiWx917_sdk.gni")
-} else {
-  import("../../efr32_sdk.gni")
-}
+import("//build_overrides/chip.gni")
 
 declare_args() {
-  sl_provision_root = "${matter_support_root}/provision"
+  # We can't use matter_support_root since that forces the inclusion of silabs_board.gni
+  # which has an assert that gets triggered for non-silabs specific builds.
+  sl_provision_root = "${chip_root}/third_party/silabs/matter_support/provision"
 }


### PR DESCRIPTION
#### Description
PR removes the dependency on the `silabs_board.gni` files. 

`silabs_board.gni` has an assert that checks if `silabs_board` is set to a supported value. This issue with this assert is for unit tests and bootstrap for example, that variable is not set. 

For any dependency tree that is used outside of silabs specific use-cases, we cannot depend on the `silabs_boards.gni`.

#### Tests
Bootstrap, built an app and unit tests