### PR TITLE
Update workflows to be more flexibility

### DIFF
--- a/.github/workflows/prevent-provision-changes.yml
+++ b/.github/workflows/prevent-provision-changes.yml
@@ -50,3 +50,24 @@ jobs:
             if (unauthorizedChanges) {
               core.setFailed('Unauthorized changes detected in the provision directory.');
             }
+
+      # This step is necessary since the bot doesn't have the necessary permissions to trigger the CI
+      - name: Close and re-open PR to trigger the CI
+        if: ${{ github.actor == 'github-actions[bot]' }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.WORKFLOW_TOKEN }}
+          script: |
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              state: 'closed'
+            });
+
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              state: 'open'
+            });

--- a/.github/workflows/prevent-provision-changes.yml
+++ b/.github/workflows/prevent-provision-changes.yml
@@ -19,19 +19,29 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const { data: files } = await github.rest.pulls.listFiles({
+            const { data: commits } = await github.rest.pulls.listCommits({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.payload.pull_request.number
             });
 
-            const changedFiles = files.map(file => file.filename);
-            console.log('Changed files:', changedFiles);
+            for (const commit of commits) {
+              const { data: files } = await github.rest.repos.getCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: commit.sha
+              });
 
-            const unauthorizedChanges = changedFiles.some(file => 
-              file.startsWith('provision/libs/') || file.startsWith('provision/headers/')
-            );
-            
-            if (unauthorizedChanges) {
-              core.setFailed(`Unauthorized changes detected in the provision directory by ${context.actor}`);
+              const changedFiles = files.files.map(file => file.filename);
+              console.log(`Changed files in commit ${commit.sha}:`, changedFiles);
+
+              const unauthorizedChanges = files.files.some(file => 
+                (file.filename.startsWith('provision/libs/') || file.filename.startsWith('provision/headers/')) && 
+                file.additions > 0 && file.deletions > 0 && commit.author.login !== 'github-actions[bot]'
+              );
+
+              if (unauthorizedChanges) {
+                core.setFailed(`Unauthorized changes detected in the provision directory by ${commit.author.login} in commit ${commit.sha}`);
+                break;
+              }
             }

--- a/.github/workflows/prevent-provision-changes.yml
+++ b/.github/workflows/prevent-provision-changes.yml
@@ -39,7 +39,8 @@ jobs:
 
               if (files.files.some(file => 
                 (file.filename.startsWith('provision/libs/') || file.filename.startsWith('provision/headers/')) && 
-                file.additions > 0 && file.deletions > 0 && commit.author.login !== 'github-actions[bot]'
+                (file.additions > 0 || file.deletions > 0 || file.status === 'added' || file.status === 'removed') && 
+                commit.author.login !== 'github-actions[bot]'
               )) {
                 unauthorizedChanges = true;
                 console.log(`Unauthorized changes detected in the provision directory by ${commit.author.login} in commit ${commit.sha}`);

--- a/.github/workflows/prevent-provision-changes.yml
+++ b/.github/workflows/prevent-provision-changes.yml
@@ -50,24 +50,3 @@ jobs:
             if (unauthorizedChanges) {
               core.setFailed('Unauthorized changes detected in the provision directory.');
             }
-
-      # This step is necessary since the bot doesn't have the necessary permissions to trigger the CI
-      - name: Close and re-open PR to trigger the CI
-        if: ${{ github.actor == 'github-actions[bot]' }}
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.WORKFLOW_TOKEN }}
-          script: |
-            await github.rest.pulls.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
-              state: 'closed'
-            });
-
-            await github.rest.pulls.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
-              state: 'open'
-            });

--- a/.github/workflows/prevent-provision-changes.yml
+++ b/.github/workflows/prevent-provision-changes.yml
@@ -25,6 +25,8 @@ jobs:
               pull_number: context.payload.pull_request.number
             });
 
+            let unauthorizedChanges = false;
+
             for (const commit of commits) {
               const { data: files } = await github.rest.repos.getCommit({
                 owner: context.repo.owner,
@@ -35,13 +37,15 @@ jobs:
               const changedFiles = files.files.map(file => file.filename);
               console.log(`Changed files in commit ${commit.sha}:`, changedFiles);
 
-              const unauthorizedChanges = files.files.some(file => 
+              if (files.files.some(file => 
                 (file.filename.startsWith('provision/libs/') || file.filename.startsWith('provision/headers/')) && 
                 file.additions > 0 && file.deletions > 0 && commit.author.login !== 'github-actions[bot]'
-              );
-
-              if (unauthorizedChanges) {
-                core.setFailed(`Unauthorized changes detected in the provision directory by ${commit.author.login} in commit ${commit.sha}`);
-                break;
+              )) {
+                unauthorizedChanges = true;
+                console.log(`Unauthorized changes detected in the provision directory by ${commit.author.login} in commit ${commit.sha}`);
               }
+            }
+
+            if (unauthorizedChanges) {
+              core.setFailed('Unauthorized changes detected in the provision directory.');
             }

--- a/.github/workflows/publish-provisoning.yaml
+++ b/.github/workflows/publish-provisoning.yaml
@@ -127,3 +127,22 @@ jobs:
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Open and Close PR
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.WORKFLOW_TOKEN }}
+          script: |
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              state: 'closed'
+            });
+
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              state: 'open'
+            });

--- a/.github/workflows/publish-provisoning.yaml
+++ b/.github/workflows/publish-provisoning.yaml
@@ -127,8 +127,10 @@ jobs:
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Open and Close PR
+      
+      # This step is necessary since the bot doesn't have the necessary permissions to trigger the CI
+      - name: Close and re-open PR to trigger the CI
+        if: ${{ github.actor == 'github-actions[bot]' }}
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.WORKFLOW_TOKEN }}


### PR DESCRIPTION
#### Problem / Feature
- When github bot opened a PR, the actions were not being triggered which prevents th PR from being merged.
- A dev could not push changes to the automation PRs without the CI failing

#### Change overview
- Adds a close / open PR to trigger CI
- Modified the change protection to check individual commits