### PR TITLE
Add provision build setup

### DIFF
--- a/provision/BUILD.gn
+++ b/provision/BUILD.gn
@@ -1,0 +1,34 @@
+# Copyright (c) 2025 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+config("provision-config") {
+  include_dirs = [ "." ]
+
+  # TODO: Link this to a gn argument to be able to disable the example credentials
+  defines = [ "SL_MATTER_ENABLE_EXAMPLE_CREDENTIALS=1" ]
+}
+
+source_set("headers") {
+  sources = [
+    "headers/AttestationKey.h",
+    "headers/ProvisionChannel.h",
+    "headers/ProvisionEncoder.h",
+    "headers/ProvisionManager.h",
+    "headers/ProvisionProtocol.h",
+    "headers/ProvisionStorage.h",
+    "headers/ProvisionedDataProvider.h",
+  ]
+
+  public_configs = [ ":provision-config" ]
+}

--- a/provision/args.gni
+++ b/provision/args.gni
@@ -1,0 +1,21 @@
+# Copyright (c) 2025 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+
+declare_args() {
+  # We can't use matter_support_root since that forces the inclusion of silabs_board.gni
+  # which has an assert that gets triggered for non-silabs specific builds.
+  sl_provision_root = "${chip_root}/third_party/silabs/matter_support/provision"
+}


### PR DESCRIPTION
#### Description 
PR adds the GN structure to use the provisioning headers and libs from the matter_support repository