### PR TITLE
[WiFi] Removing the unused parameters

### DIFF
--- a/sockets/ifaddrs.h
+++ b/sockets/ifaddrs.h
@@ -17,8 +17,6 @@ struct ifaddrs
 // Hardcoded function to return a single interface
 static inline int getifaddrs(struct ifaddrs ** ifap)
 {
-    static struct sockaddr_in addr;
-    static struct sockaddr_in netmask;
     static struct ifaddrs ifa;
 
     ifa.ifa_next  = NULL;


### PR DESCRIPTION
#### Problem / Feature
There were a few unused parameters in the sockets code.

#### Change overview
Removing the unused parameters

#### Testing
Tested build with 917 NCP