### PR TITLE
update eusart speed

### DIFF
--- a/board-support/efr32/efr32mg24/BRD2601B/config/sl_uartdrv_eusart_vcom_config.h
+++ b/board-support/efr32/efr32mg24/BRD2601B/config/sl_uartdrv_eusart_vcom_config.h
@@ -37,7 +37,7 @@
 // <h> EUSART settings
 // <o SL_UARTDRV_EUSART_VCOM_BAUDRATE> Baud rate
 // <i> Default: 115200
-#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        115200
+#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        921600
 
 // <o SL_UARTDRV_EUSART_VCOM_LF_MODE> Low frequency mode
 // <true=> True

--- a/board-support/efr32/efr32mg24/BRD2703A/config/sl_uartdrv_eusart_vcom_config.h
+++ b/board-support/efr32/efr32mg24/BRD2703A/config/sl_uartdrv_eusart_vcom_config.h
@@ -37,7 +37,7 @@
 // <h> EUSART settings
 // <o SL_UARTDRV_EUSART_VCOM_BAUDRATE> Baud rate
 // <i> Default: 115200
-#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        115200
+#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        921600
 
 // <o SL_UARTDRV_EUSART_VCOM_LF_MODE> Low frequency mode
 // <true=> True

--- a/board-support/efr32/efr32mg24/BRD4186A/config/sl_uartdrv_eusart_vcom_config.h
+++ b/board-support/efr32/efr32mg24/BRD4186A/config/sl_uartdrv_eusart_vcom_config.h
@@ -37,7 +37,7 @@
 // <h> EUSART settings
 // <o SL_UARTDRV_EUSART_VCOM_BAUDRATE> Baud rate
 // <i> Default: 115200
-#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        115200
+#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        921600
 
 // <o SL_UARTDRV_EUSART_VCOM_LF_MODE> Low frequency mode
 // <true=> True

--- a/board-support/efr32/efr32mg24/BRD4186C/config/sl_uartdrv_eusart_vcom_config.h
+++ b/board-support/efr32/efr32mg24/BRD4186C/config/sl_uartdrv_eusart_vcom_config.h
@@ -37,7 +37,7 @@
 // <h> EUSART settings
 // <o SL_UARTDRV_EUSART_VCOM_BAUDRATE> Baud rate
 // <i> Default: 115200
-#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        115200
+#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        921600
 
 // <o SL_UARTDRV_EUSART_VCOM_LF_MODE> Low frequency mode
 // <true=> True

--- a/board-support/efr32/efr32mg24/BRD4187A/config/sl_uartdrv_eusart_vcom_config.h
+++ b/board-support/efr32/efr32mg24/BRD4187A/config/sl_uartdrv_eusart_vcom_config.h
@@ -37,7 +37,7 @@
 // <h> EUSART settings
 // <o SL_UARTDRV_EUSART_VCOM_BAUDRATE> Baud rate
 // <i> Default: 115200
-#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        115200
+#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        921600
 
 // <o SL_UARTDRV_EUSART_VCOM_LF_MODE> Low frequency mode
 // <true=> True

--- a/board-support/efr32/efr32mg24/BRD4187C/config/sl_uartdrv_eusart_vcom_config.h
+++ b/board-support/efr32/efr32mg24/BRD4187C/config/sl_uartdrv_eusart_vcom_config.h
@@ -37,7 +37,7 @@
 // <h> EUSART settings
 // <o SL_UARTDRV_EUSART_VCOM_BAUDRATE> Baud rate
 // <i> Default: 115200
-#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        115200
+#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        921600
 
 // <o SL_UARTDRV_EUSART_VCOM_LF_MODE> Low frequency mode
 // <true=> True

--- a/board-support/efr32/efr32mg26/BRD2608A/config/sl_uartdrv_eusart_vcom_config.h
+++ b/board-support/efr32/efr32mg26/BRD2608A/config/sl_uartdrv_eusart_vcom_config.h
@@ -37,7 +37,7 @@
 // <h> EUSART settings
 // <o SL_UARTDRV_EUSART_VCOM_BAUDRATE> Baud rate
 // <i> Default: 115200
-#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        115200
+#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        921600
 
 // <o SL_UARTDRV_EUSART_VCOM_LF_MODE> Low frequency mode
 // <true=> True

--- a/board-support/efr32/efr32mg26/BRD4116A/config/sl_uartdrv_eusart_vcom_config.h
+++ b/board-support/efr32/efr32mg26/BRD4116A/config/sl_uartdrv_eusart_vcom_config.h
@@ -37,7 +37,7 @@
 // <h> EUSART settings
 // <o SL_UARTDRV_EUSART_VCOM_BAUDRATE> Baud rate
 // <i> Default: 115200
-#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        115200
+#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        921600
 
 // <o SL_UARTDRV_EUSART_VCOM_LF_MODE> Low frequency mode
 // <true=> True

--- a/board-support/efr32/efr32mg26/BRD4117A/config/sl_uartdrv_eusart_vcom_config.h
+++ b/board-support/efr32/efr32mg26/BRD4117A/config/sl_uartdrv_eusart_vcom_config.h
@@ -37,7 +37,7 @@
 // <h> EUSART settings
 // <o SL_UARTDRV_EUSART_VCOM_BAUDRATE> Baud rate
 // <i> Default: 115200
-#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        115200
+#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        921600
 
 // <o SL_UARTDRV_EUSART_VCOM_LF_MODE> Low frequency mode
 // <true=> True

--- a/board-support/efr32/efr32mg26/BRD4118A/config/sl_uartdrv_eusart_vcom_config.h
+++ b/board-support/efr32/efr32mg26/BRD4118A/config/sl_uartdrv_eusart_vcom_config.h
@@ -37,7 +37,7 @@
 // <h> EUSART settings
 // <o SL_UARTDRV_EUSART_VCOM_BAUDRATE> Baud rate
 // <i> Default: 115200
-#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        115200
+#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        921600
 
 // <o SL_UARTDRV_EUSART_VCOM_LF_MODE> Low frequency mode
 // <true=> True

--- a/board-support/efr32/mgm24/BRD2704A/config/sl_uartdrv_eusart_vcom_config.h
+++ b/board-support/efr32/mgm24/BRD2704A/config/sl_uartdrv_eusart_vcom_config.h
@@ -37,7 +37,7 @@
 // <h> EUSART settings
 // <o SL_UARTDRV_EUSART_VCOM_BAUDRATE> Baud rate
 // <i> Default: 115200
-#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        115200
+#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        921600
 
 // <o SL_UARTDRV_EUSART_VCOM_LF_MODE> Low frequency mode
 // <true=> True

--- a/board-support/efr32/mgm24/BRD4316A/config/sl_uartdrv_eusart_vcom_config.h
+++ b/board-support/efr32/mgm24/BRD4316A/config/sl_uartdrv_eusart_vcom_config.h
@@ -37,7 +37,7 @@
 // <h> EUSART settings
 // <o SL_UARTDRV_EUSART_VCOM_BAUDRATE> Baud rate
 // <i> Default: 115200
-#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        115200
+#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        921600
 
 // <o SL_UARTDRV_EUSART_VCOM_LF_MODE> Low frequency mode
 // <true=> True

--- a/board-support/efr32/mgm24/BRD4317A/config/sl_uartdrv_eusart_vcom_config.h
+++ b/board-support/efr32/mgm24/BRD4317A/config/sl_uartdrv_eusart_vcom_config.h
@@ -37,7 +37,7 @@
 // <h> EUSART settings
 // <o SL_UARTDRV_EUSART_VCOM_BAUDRATE> Baud rate
 // <i> Default: 115200
-#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        115200
+#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        921600
 
 // <o SL_UARTDRV_EUSART_VCOM_LF_MODE> Low frequency mode
 // <true=> True

--- a/board-support/efr32/mgm24/BRD4318A/config/sl_uartdrv_eusart_vcom_config.h
+++ b/board-support/efr32/mgm24/BRD4318A/config/sl_uartdrv_eusart_vcom_config.h
@@ -37,7 +37,7 @@
 // <h> EUSART settings
 // <o SL_UARTDRV_EUSART_VCOM_BAUDRATE> Baud rate
 // <i> Default: 115200
-#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        115200
+#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        921600
 
 // <o SL_UARTDRV_EUSART_VCOM_LF_MODE> Low frequency mode
 // <true=> True

--- a/board-support/efr32/mgm24/BRD4319A/config/sl_uartdrv_eusart_vcom_config.h
+++ b/board-support/efr32/mgm24/BRD4319A/config/sl_uartdrv_eusart_vcom_config.h
@@ -37,7 +37,7 @@
 // <h> EUSART settings
 // <o SL_UARTDRV_EUSART_VCOM_BAUDRATE> Baud rate
 // <i> Default: 115200
-#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        115200
+#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        921600
 
 // <o SL_UARTDRV_EUSART_VCOM_LF_MODE> Low frequency mode
 // <true=> True


### PR DESCRIPTION
#### Problem / Feature
Too much RAM used for EUSART log buffer. At init, we generate ~20K of logs which at 115200 takes around 16ms to transmit. 

#### Change overview
Increasing the baudrate, reduces transmission time to ~2ms thus allowing us to reduces the EUSART buffer size.

#### Testing
Tested with MG24 (BRD4187C)