### PR TITLE
Update UART Logs

### DIFF
--- a/board-support/efr32/efr32mg24/BRD2601B/config/sl_uartdrv_eusart_vcom_config.h
+++ b/board-support/efr32/efr32mg24/BRD2601B/config/sl_uartdrv_eusart_vcom_config.h
@@ -37,7 +37,11 @@
 // <h> EUSART settings
 // <o SL_UARTDRV_EUSART_VCOM_BAUDRATE> Baud rate
 // <i> Default: 115200
+#if defined(VERBOSE_MODE) && (VERBOSE_MODE ==1)
 #define SL_UARTDRV_EUSART_VCOM_BAUDRATE        921600
+#else 
+#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        115200
+#endif
 
 // <o SL_UARTDRV_EUSART_VCOM_LF_MODE> Low frequency mode
 // <true=> True

--- a/board-support/efr32/efr32mg24/BRD2703A/config/sl_uartdrv_eusart_vcom_config.h
+++ b/board-support/efr32/efr32mg24/BRD2703A/config/sl_uartdrv_eusart_vcom_config.h
@@ -37,7 +37,11 @@
 // <h> EUSART settings
 // <o SL_UARTDRV_EUSART_VCOM_BAUDRATE> Baud rate
 // <i> Default: 115200
+#if defined(VERBOSE_MODE) && (VERBOSE_MODE ==1)
 #define SL_UARTDRV_EUSART_VCOM_BAUDRATE        921600
+#else 
+#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        115200
+#endif
 
 // <o SL_UARTDRV_EUSART_VCOM_LF_MODE> Low frequency mode
 // <true=> True

--- a/board-support/efr32/efr32mg24/BRD4186A/config/sl_uartdrv_eusart_vcom_config.h
+++ b/board-support/efr32/efr32mg24/BRD4186A/config/sl_uartdrv_eusart_vcom_config.h
@@ -37,7 +37,11 @@
 // <h> EUSART settings
 // <o SL_UARTDRV_EUSART_VCOM_BAUDRATE> Baud rate
 // <i> Default: 115200
+#if defined(VERBOSE_MODE) && (VERBOSE_MODE ==1)
 #define SL_UARTDRV_EUSART_VCOM_BAUDRATE        921600
+#else 
+#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        115200
+#endif
 
 // <o SL_UARTDRV_EUSART_VCOM_LF_MODE> Low frequency mode
 // <true=> True

--- a/board-support/efr32/efr32mg24/BRD4186C/config/sl_uartdrv_eusart_vcom_config.h
+++ b/board-support/efr32/efr32mg24/BRD4186C/config/sl_uartdrv_eusart_vcom_config.h
@@ -37,7 +37,11 @@
 // <h> EUSART settings
 // <o SL_UARTDRV_EUSART_VCOM_BAUDRATE> Baud rate
 // <i> Default: 115200
+#if defined(VERBOSE_MODE) && (VERBOSE_MODE ==1)
 #define SL_UARTDRV_EUSART_VCOM_BAUDRATE        921600
+#else 
+#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        115200
+#endif
 
 // <o SL_UARTDRV_EUSART_VCOM_LF_MODE> Low frequency mode
 // <true=> True

--- a/board-support/efr32/efr32mg24/BRD4187A/config/sl_uartdrv_eusart_vcom_config.h
+++ b/board-support/efr32/efr32mg24/BRD4187A/config/sl_uartdrv_eusart_vcom_config.h
@@ -37,7 +37,11 @@
 // <h> EUSART settings
 // <o SL_UARTDRV_EUSART_VCOM_BAUDRATE> Baud rate
 // <i> Default: 115200
+#if defined(VERBOSE_MODE) && (VERBOSE_MODE ==1)
 #define SL_UARTDRV_EUSART_VCOM_BAUDRATE        921600
+#else 
+#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        115200
+#endif
 
 // <o SL_UARTDRV_EUSART_VCOM_LF_MODE> Low frequency mode
 // <true=> True

--- a/board-support/efr32/efr32mg24/BRD4187C/config/sl_uartdrv_eusart_vcom_config.h
+++ b/board-support/efr32/efr32mg24/BRD4187C/config/sl_uartdrv_eusart_vcom_config.h
@@ -37,7 +37,11 @@
 // <h> EUSART settings
 // <o SL_UARTDRV_EUSART_VCOM_BAUDRATE> Baud rate
 // <i> Default: 115200
+#if defined(VERBOSE_MODE) && (VERBOSE_MODE ==1)
 #define SL_UARTDRV_EUSART_VCOM_BAUDRATE        921600
+#else 
+#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        115200
+#endif
 
 // <o SL_UARTDRV_EUSART_VCOM_LF_MODE> Low frequency mode
 // <true=> True

--- a/board-support/efr32/efr32mg26/BRD2608A/config/sl_uartdrv_eusart_vcom_config.h
+++ b/board-support/efr32/efr32mg26/BRD2608A/config/sl_uartdrv_eusart_vcom_config.h
@@ -37,7 +37,11 @@
 // <h> EUSART settings
 // <o SL_UARTDRV_EUSART_VCOM_BAUDRATE> Baud rate
 // <i> Default: 115200
+#if defined(VERBOSE_MODE) && (VERBOSE_MODE ==1)
 #define SL_UARTDRV_EUSART_VCOM_BAUDRATE        921600
+#else 
+#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        115200
+#endif
 
 // <o SL_UARTDRV_EUSART_VCOM_LF_MODE> Low frequency mode
 // <true=> True

--- a/board-support/efr32/efr32mg26/BRD4116A/config/sl_uartdrv_eusart_vcom_config.h
+++ b/board-support/efr32/efr32mg26/BRD4116A/config/sl_uartdrv_eusart_vcom_config.h
@@ -37,7 +37,11 @@
 // <h> EUSART settings
 // <o SL_UARTDRV_EUSART_VCOM_BAUDRATE> Baud rate
 // <i> Default: 115200
+#if defined(VERBOSE_MODE) && (VERBOSE_MODE ==1)
 #define SL_UARTDRV_EUSART_VCOM_BAUDRATE        921600
+#else 
+#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        115200
+#endif
 
 // <o SL_UARTDRV_EUSART_VCOM_LF_MODE> Low frequency mode
 // <true=> True

--- a/board-support/efr32/efr32mg26/BRD4117A/config/sl_uartdrv_eusart_vcom_config.h
+++ b/board-support/efr32/efr32mg26/BRD4117A/config/sl_uartdrv_eusart_vcom_config.h
@@ -37,7 +37,11 @@
 // <h> EUSART settings
 // <o SL_UARTDRV_EUSART_VCOM_BAUDRATE> Baud rate
 // <i> Default: 115200
+#if defined(VERBOSE_MODE) && (VERBOSE_MODE ==1)
 #define SL_UARTDRV_EUSART_VCOM_BAUDRATE        921600
+#else 
+#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        115200
+#endif
 
 // <o SL_UARTDRV_EUSART_VCOM_LF_MODE> Low frequency mode
 // <true=> True

--- a/board-support/efr32/efr32mg26/BRD4118A/config/sl_uartdrv_eusart_vcom_config.h
+++ b/board-support/efr32/efr32mg26/BRD4118A/config/sl_uartdrv_eusart_vcom_config.h
@@ -37,7 +37,11 @@
 // <h> EUSART settings
 // <o SL_UARTDRV_EUSART_VCOM_BAUDRATE> Baud rate
 // <i> Default: 115200
+#if defined(VERBOSE_MODE) && (VERBOSE_MODE ==1)
 #define SL_UARTDRV_EUSART_VCOM_BAUDRATE        921600
+#else 
+#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        115200
+#endif
 
 // <o SL_UARTDRV_EUSART_VCOM_LF_MODE> Low frequency mode
 // <true=> True

--- a/board-support/efr32/mgm24/BRD2704A/config/sl_uartdrv_eusart_vcom_config.h
+++ b/board-support/efr32/mgm24/BRD2704A/config/sl_uartdrv_eusart_vcom_config.h
@@ -37,7 +37,11 @@
 // <h> EUSART settings
 // <o SL_UARTDRV_EUSART_VCOM_BAUDRATE> Baud rate
 // <i> Default: 115200
+#if defined(VERBOSE_MODE) && (VERBOSE_MODE ==1)
 #define SL_UARTDRV_EUSART_VCOM_BAUDRATE        921600
+#else 
+#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        115200
+#endif
 
 // <o SL_UARTDRV_EUSART_VCOM_LF_MODE> Low frequency mode
 // <true=> True

--- a/board-support/efr32/mgm24/BRD4316A/config/sl_uartdrv_eusart_vcom_config.h
+++ b/board-support/efr32/mgm24/BRD4316A/config/sl_uartdrv_eusart_vcom_config.h
@@ -37,7 +37,11 @@
 // <h> EUSART settings
 // <o SL_UARTDRV_EUSART_VCOM_BAUDRATE> Baud rate
 // <i> Default: 115200
+#if defined(VERBOSE_MODE) && (VERBOSE_MODE ==1)
 #define SL_UARTDRV_EUSART_VCOM_BAUDRATE        921600
+#else 
+#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        115200
+#endif
 
 // <o SL_UARTDRV_EUSART_VCOM_LF_MODE> Low frequency mode
 // <true=> True

--- a/board-support/efr32/mgm24/BRD4317A/config/sl_uartdrv_eusart_vcom_config.h
+++ b/board-support/efr32/mgm24/BRD4317A/config/sl_uartdrv_eusart_vcom_config.h
@@ -37,7 +37,11 @@
 // <h> EUSART settings
 // <o SL_UARTDRV_EUSART_VCOM_BAUDRATE> Baud rate
 // <i> Default: 115200
+#if defined(VERBOSE_MODE) && (VERBOSE_MODE ==1)
 #define SL_UARTDRV_EUSART_VCOM_BAUDRATE        921600
+#else 
+#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        115200
+#endif
 
 // <o SL_UARTDRV_EUSART_VCOM_LF_MODE> Low frequency mode
 // <true=> True

--- a/board-support/efr32/mgm24/BRD4318A/config/sl_uartdrv_eusart_vcom_config.h
+++ b/board-support/efr32/mgm24/BRD4318A/config/sl_uartdrv_eusart_vcom_config.h
@@ -37,7 +37,11 @@
 // <h> EUSART settings
 // <o SL_UARTDRV_EUSART_VCOM_BAUDRATE> Baud rate
 // <i> Default: 115200
+#if defined(VERBOSE_MODE) && (VERBOSE_MODE ==1)
 #define SL_UARTDRV_EUSART_VCOM_BAUDRATE        921600
+#else 
+#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        115200
+#endif
 
 // <o SL_UARTDRV_EUSART_VCOM_LF_MODE> Low frequency mode
 // <true=> True

--- a/board-support/efr32/mgm24/BRD4319A/config/sl_uartdrv_eusart_vcom_config.h
+++ b/board-support/efr32/mgm24/BRD4319A/config/sl_uartdrv_eusart_vcom_config.h
@@ -37,7 +37,11 @@
 // <h> EUSART settings
 // <o SL_UARTDRV_EUSART_VCOM_BAUDRATE> Baud rate
 // <i> Default: 115200
+#if defined(VERBOSE_MODE) && (VERBOSE_MODE ==1)
 #define SL_UARTDRV_EUSART_VCOM_BAUDRATE        921600
+#else 
+#define SL_UARTDRV_EUSART_VCOM_BAUDRATE        115200
+#endif
 
 // <o SL_UARTDRV_EUSART_VCOM_LF_MODE> Low frequency mode
 // <true=> True


### PR DESCRIPTION
#### Problem / Feature
defaulting to 921600 has some issue, introduce a verbose mode to enable/disable high log output, thus removing the need to always run at 921600

#### Change overview
Add defines to toggle the baudrate

#### Testing
tested with MG24 locally