### PR TITLE
[SL-UP] Set the systick value based upon the configured clock rate

### DIFF
--- a/board-support/si91x/support/hal/rsi_hal_mcu_m4.c
+++ b/board-support/si91x/support/hal/rsi_hal_mcu_m4.c
@@ -20,7 +20,9 @@
 #include "rsi_rom_clks.h"
 #include "silabs_utils.h"
 #include "sl_component_catalog.h"
+#if CHIP_CONFIG_ENABLE_ICD_SERVER == 0
 #include "FreeRTOSConfig.h"
+#endif
 
 #ifdef SL_CATALOG_SIMPLE_BUTTON_PRESENT
 #include "sl_si91x_button_pin_config.h"
@@ -52,6 +54,7 @@
 void sl_button_on_change(uint8_t btn, uint8_t btnAction);
 #endif  //SL_CATALOG_SIMPLE_BUTTON_PRESENT
 
+#if CHIP_CONFIG_ENABLE_ICD_SERVER == 0
 int soc_pll_config(void) {
   int32_t status = RSI_OK;
 
@@ -81,6 +84,7 @@ int soc_pll_config(void) {
 #endif /* SWITCH_QSPI_TO_SOC_PLL */
   return 0;
 }
+#endif
 
 #ifdef SL_CATALOG_SIMPLE_BUTTON_PRESENT
 void sl_si91x_button_isr(uint8_t pin, int8_t state) {


### PR DESCRIPTION
#### Problem / Feature
After integrating the sl_main component into the Matter application, we observed a timing discrepancy in the device clock. Specifically, the clock was lagging by approximately 2%—for every 100 seconds of real time, the device clock advanced only 98 seconds. This deviation  resulted in failure of time-sensitive operation. The deviation is seen as the tick rate is not being used while setting the systick configuration
This PR fixes : MATTER-5395

#### Change overview
Leveraging the tick rate macro while setting the systick configuration.

#### Testing
Tested the timing related test-cases (like cadmin test-cases, where a commissioning window would be opened only for a particular amount of time) with lighting-app and lock-app and ensured that the device clock is functioning without any errors.