### PR TITLE
[SL-UP] Fix build errors for 917SoC ICD apps. 

### DIFF
--- a/board-support/si91x/support/hal/rsi_hal_mcu_m4.c
+++ b/board-support/si91x/support/hal/rsi_hal_mcu_m4.c
@@ -20,9 +20,9 @@
 #include "rsi_rom_clks.h"
 #include "silabs_utils.h"
 #include "sl_component_catalog.h"
-#if CHIP_CONFIG_ENABLE_ICD_SERVER == 0
+#ifndef SL_ICD_ENABLED
 #include "FreeRTOSConfig.h"
-#endif
+#endif // !defined (SL_ICD_ENABLED)
 
 #ifdef SL_CATALOG_SIMPLE_BUTTON_PRESENT
 #include "sl_si91x_button_pin_config.h"
@@ -54,7 +54,7 @@
 void sl_button_on_change(uint8_t btn, uint8_t btnAction);
 #endif  //SL_CATALOG_SIMPLE_BUTTON_PRESENT
 
-#if CHIP_CONFIG_ENABLE_ICD_SERVER == 0
+#ifndef SL_ICD_ENABLED
 int soc_pll_config(void) {
   int32_t status = RSI_OK;
 
@@ -84,7 +84,7 @@ int soc_pll_config(void) {
 #endif /* SWITCH_QSPI_TO_SOC_PLL */
   return 0;
 }
-#endif
+#endif // !defined (SL_ICD_ENABLED)
 
 #ifdef SL_CATALOG_SIMPLE_BUTTON_PRESENT
 void sl_si91x_button_isr(uint8_t pin, int8_t state) {


### PR DESCRIPTION
#### Problem
For 917SOC, the gn build in matter_sdk for lock app fails with this commit : https://github.com/SiliconLabsSoftware/matter_support/commit/dd0b22368b0f7a27b9792dcaf592600b85f90317

#### Change overview
This PR fixes the build issue by adding proper define guards for the part of code which is meant to be executed only for non-ICD apps.

#### Testing
Tested the gn build and SLC build in matter_extension and matter_sdk repos with the changes.