### PR TITLE
[Cherry-Pick] Set the systick value based upon the configured clock rate

### DIFF
--- a/board-support/si91x/support/hal/rsi_hal_mcu_m4.c
+++ b/board-support/si91x/support/hal/rsi_hal_mcu_m4.c
@@ -20,6 +20,9 @@
 #include "rsi_rom_clks.h"
 #include "silabs_utils.h"
 #include "sl_component_catalog.h"
+#ifndef SL_ICD_ENABLED
+#include "FreeRTOSConfig.h"
+#endif // !defined (SL_ICD_ENABLED)
 
 #ifdef SL_CATALOG_SIMPLE_BUTTON_PRESENT
 #include "sl_si91x_button_pin_config.h"
@@ -51,6 +54,7 @@
 void sl_button_on_change(uint8_t btn, uint8_t btnAction);
 #endif  //SL_CATALOG_SIMPLE_BUTTON_PRESENT
 
+#ifndef SL_ICD_ENABLED
 int soc_pll_config(void) {
   int32_t status = RSI_OK;
 
@@ -63,7 +67,7 @@ int soc_pll_config(void) {
   // Switch M4 clock to PLL clock for speed operations
   RSI_CLK_M4SocClkConfig(M4CLK, M4_SOCPLLCLK, 0);
 
-  SysTick_Config(SystemCoreClock / 1000);
+  SysTick_Config(SystemCoreClock / configTICK_RATE_HZ);
   DEBUGINIT();
 
 #ifdef SWITCH_QSPI_TO_SOC_PLL
@@ -80,6 +84,7 @@ int soc_pll_config(void) {
 #endif /* SWITCH_QSPI_TO_SOC_PLL */
   return 0;
 }
+#endif // !defined (SL_ICD_ENABLED)
 
 #ifdef SL_CATALOG_SIMPLE_BUTTON_PRESENT
 void sl_si91x_button_isr(uint8_t pin, int8_t state) {


### PR DESCRIPTION
#### Problem / Feature
This PR upstreams the clock-setting fixes for 917SoC from release_2.7-1.4 branch to main.

#### Change overview
Below commits from release_2.7-1.4 branch are being cherry-picked : 
https://github.com/SiliconLabsSoftware/matter_support/pull/158
https://github.com/SiliconLabsSoftware/matter_support/pull/165


#### Testing
Tested the timing related test-cases (like cadmin test-cases, where a commissioning window would be opened only for a particular amount of time) with lighting-app and lock-app and ensured that the device clock is functioning without any errors.