### PR TITLE
Fix HardFault due to uninitialized SPIDriver in BRD4187C NCP build and unrecognized symbols in BRD4186C NCP Build

### DIFF
--- a/board-support/efr32/efr32mg24/BRD4186C/autogen/sl_event_handler.c
+++ b/board-support/efr32/efr32mg24/BRD4186C/autogen/sl_event_handler.c
@@ -107,6 +107,9 @@ void sl_driver_init(void)
 #else
   sl_simple_led_init_instances();
 #endif //(SL_MATTER_RGB_LED_ENABLED) && SL_MATTER_RGB_LED_ENABLED == 1)
+#ifdef SL_WIFI
+  sl_spidrv_init_instances();
+#endif //SL_WIFI
   #if defined(CONFIG_ENABLE_UART)
   sl_uartdrv_init_instances();
 #endif // CONFIG_ENABLE_UART

--- a/board-support/efr32/efr32mg24/BRD4186C/autogen/sl_event_handler.c
+++ b/board-support/efr32/efr32mg24/BRD4186C/autogen/sl_event_handler.c
@@ -58,8 +58,13 @@ void sli_service_permanent_allocation(void)
 
 void sli_stack_permanent_allocation(void)
 {
+#if !SLI_SI91X_ENABLE_BLE
   sli_bt_stack_permanent_allocation();
+#endif // !SLI_SI91X_ENABLE_BLE
+#ifdef SL_OT_ENABLE
   sl_ot_rtos_perm_allocation();
+#endif // SL_OT_ENABLE
+
 }
 
 void sli_internal_permanent_allocation(void)

--- a/board-support/efr32/efr32mg24/BRD4187C/autogen/sl_event_handler.c
+++ b/board-support/efr32/efr32mg24/BRD4187C/autogen/sl_event_handler.c
@@ -107,6 +107,9 @@ void sl_driver_init(void)
 #else
   sl_simple_led_init_instances();
 #endif //(SL_MATTER_RGB_LED_ENABLED) && SL_MATTER_RGB_LED_ENABLED == 1)
+#ifdef SL_WIFI
+  sl_spidrv_init_instances();
+#endif //SL_WIFI
 #if defined(CONFIG_ENABLE_UART)
   sl_uartdrv_init_instances();
 #endif // CONFIG_ENABLE_UART


### PR DESCRIPTION
### BRD4187C
### Problem
A hard fault occurred because the UART driver attempted to dereference an uninitialized UART driver handle.

### Change Overview

Added a call to `sl_spidrv_init_instances()` based on the initialization code generated by SLC. This ensures that the required driver instances are initialized before they are used.

### Testing

Validated by building for thread
Validated the change on the BRD4187C NCP Lock application by:

* Building the application successfully
* Commissioning the device
* Issuing cluster commands and verifying expected behavior

### BRD4186C
### Problem 
```[949/952] ld ./matter-silabs-lock-example.out
FAILED: [code=1] matter-silabs-lock-example.out 
arm-none-eabi-g++ -T../../../../examples/lock-app/silabs/third_party/connectedhomeip/examples/platform/silabs/ldscripts/efr32mg24.ld -Wl,--defsym -Wl,SILABS_WIFI=1 -march=armv8-m.main+dsp -mcpu=cortex-m33 -mabi=aapcs -mfpu=fpv5-sp-d16 -mfloat-abi=hard -mthumb -Og --specs=nosys.specs --specs=nano.specs -Werror -Wl,--fatal-warnings -fdiagnostics-color -Wl,--gc-sections -Wl,--as-needed -fno-lto -Wl,--no-warn-rwx-segment -Wl,--wrap=MemoryAlloc -Wl,--wrap=_malloc_r -Wl,--wrap=_realloc_r -Wl,--wrap=_free_r -Wl,--wrap=_calloc_r -Wl,--wrap=main @./matter-silabs-lock-example.out.rsp -o ./matter-silabs-lock-example.out
/home/pe1/Development/connectedhomeip/.environment/cipd/packages/arm/bin/../lib/gcc/arm-none-eabi/12.2.1/../../../../arm-none-eabi/bin/ld: obj/third_party/connectedhomeip/third_party/silabs/matter_support/board-support/efr32/efr32mg24/BRD4186C/autogen/sdk.sl_event_handler.c.o: in function `sli_stack_permanent_allocation':
/home/pe1/Development/connectedhomeip/out/wifi/BRD4186C/SiWx917/../../../../examples/lock-app/silabs/third_party/connectedhomeip/third_party/silabs/matter_support/board-support/efr32/efr32mg24/BRD4186C/autogen/sl_event_handler.c:61: undefined reference to `sli_bt_stack_permanent_allocation'
/home/pe1/Development/connectedhomeip/.environment/cipd/packages/arm/bin/../lib/gcc/arm-none-eabi/12.2.1/../../../../arm-none-eabi/bin/ld: /home/pe1/Development/connectedhomeip/out/wifi/BRD4186C/SiWx917/../../../../examples/lock-app/silabs/third_party/connectedhomeip/third_party/silabs/matter_support/board-support/efr32/efr32mg24/BRD4186C/autogen/sl_event_handler.c:62: undefined reference to `sl_ot_rtos_perm_allocation'
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
```
### Change Overview

Fixed by Adding gaurds for BLE/OT stacks based on BRD4187C for BRD4186C

### Testing 
Validated by building for both Thread and with NCP