### PR TITLE
[WF200 Removal] converted MBEDTLS_PSA_KEY_SLOT_COUNT back to its usual value 22 from 30

### DIFF
--- a/board-support/efr32/efr32mg24/BRD4186C/autogen/sli_psa_config_autogen.h
+++ b/board-support/efr32/efr32mg24/BRD4186C/autogen/sli_psa_config_autogen.h
@@ -24,8 +24,7 @@
 #define PSA_WANT_ALG_TLS12_PSK_TO_MS 1
 #define MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG
 
-// Higher matter psa key slot count (30) than the usual (22) for the wf200 ncp.
-#define MBEDTLS_PSA_KEY_SLOT_COUNT (30 + 15 + 1 + SL_PSA_KEY_USER_SLOT_COUNT + 1)
+#define MBEDTLS_PSA_KEY_SLOT_COUNT (22 + 15 + 1 + SL_PSA_KEY_USER_SLOT_COUNT + 1)
 #ifndef SL_PSA_ITS_MAX_FILES
 #define SL_PSA_ITS_MAX_FILES (1 + SL_PSA_ITS_USER_MAX_FILES)
 #endif

--- a/board-support/efr32/efr32mg24/BRD4187C/autogen/sli_psa_config_autogen.h
+++ b/board-support/efr32/efr32mg24/BRD4187C/autogen/sli_psa_config_autogen.h
@@ -24,8 +24,7 @@
 #define PSA_WANT_ALG_TLS12_PSK_TO_MS 1
 #define MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG
 
-// Higher matter psa key slot count (30) than the usual (22) for the wf200 ncp.
-#define MBEDTLS_PSA_KEY_SLOT_COUNT (30 + 15 + 1 + SL_PSA_KEY_USER_SLOT_COUNT + 1)
+#define MBEDTLS_PSA_KEY_SLOT_COUNT (22 + 15 + 1 + SL_PSA_KEY_USER_SLOT_COUNT + 1)
 #ifndef SL_PSA_ITS_MAX_FILES
 #define SL_PSA_ITS_MAX_FILES (1 + SL_PSA_ITS_USER_MAX_FILES)
 #endif


### PR DESCRIPTION
### Cherry Pick of #235 onto Release_2.10-1.6.1 Branch ([WF200 Removal] converted MBEDTLS_PSA_KEY_SLOT_COUNT back to its usual value 22 from 30) 

#### Change overview
converted MBEDTLS_PSA_KEY_SLOT_COUNT back to its usual value 22 from 30

#### Testing
Building,Commissioning and issuing cluster commands for brd4187C NCP 